### PR TITLE
Enhance allocation data

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -48,7 +48,9 @@ module.exports = {
     "release_date": "03/01/2018",
     "tier": "C",
     "status_change": "19/09/2018",
-    "allocated": true
+    "allocated": true,
+    "allocation_date": "05/01/2018",
+    "pomIndex": 2
   }, {
     "id": "3",
     "first_name": "Briano",
@@ -118,7 +120,9 @@ module.exports = {
     "release_date": "03/01/2018",
     "tier": "B",
     "status_change": "26/09/2018",
-    "allocated": true
+    "allocated": true,
+    "allocation_date": "05/01/2018",
+    "pomIndex": 3
   }, {
     "id": "8",
     "first_name": "Sollie",
@@ -146,7 +150,9 @@ module.exports = {
     "release_date": "02/01/2018",
     "tier": "D",
     "status_change": "25/09/2018",
-    "allocated": true
+    "allocated": true,
+    "allocation_date": "05/01/2018",
+    "pomIndex": 8
   }, {
     "id": "10",
     "first_name": "Hasty",
@@ -202,7 +208,9 @@ module.exports = {
     "release_date": "03/01/2018",
     "tier": "B",
     "status_change": "17/09/2018",
-    "allocated": true
+    "allocated": true,
+    "allocation_date": "05/01/2018",
+    "pomIndex": 3
   }, {
     "id": "14",
     "first_name": "Rodolph",
@@ -216,7 +224,9 @@ module.exports = {
     "release_date": "04/01/2018",
     "tier": "A",
     "status_change": "25/09/2018",
-    "allocated": true
+    "allocated": true,
+    "allocation_date": "05/01/2018",
+    "pomIndex": 9
   }, {
     "id": "15",
     "first_name": "Craggie",
@@ -230,7 +240,9 @@ module.exports = {
     "release_date": null,
     "tier": "D",
     "status_change": "25/09/2018",
-    "allocated": true
+    "allocated": true,
+    "allocation_date": "05/01/2018",
+    "pomIndex": 7
   }, {
     "id": "16",
     "first_name": "Putnem",
@@ -328,7 +340,9 @@ module.exports = {
     "release_date": null,
     "tier": "A",
     "status_change": "24/09/2018",
-    "allocated": true
+    "allocation_date": "05/01/2018",
+    "allocated": true,
+    "pomIndex": 2
   }, {
     "id": "23",
     "first_name": "Kele",
@@ -356,7 +370,9 @@ module.exports = {
     "release_date": "04/01/2018",
     "tier": "D",
     "status_change": "25/09/2018",
-    "allocated": true
+    "allocated": true,
+    "allocation_date": "05/01/2018",
+    "pomIndex": 5
   }, {
     "id": "25",
     "first_name": "Farr",
@@ -384,7 +400,9 @@ module.exports = {
     "release_date": "06/01/2018",
     "tier": "B",
     "status_change": "21/09/2018",
-    "allocated": true
+    "allocated": true,
+    "allocation_date": "05/01/2018",
+    "pomIndex": 6
   }, {
     "id": "27",
     "first_name": "Timothy",

--- a/app/filters.js
+++ b/app/filters.js
@@ -11,7 +11,7 @@ module.exports = function (env) {
     return person.first_name + ' ' + person.surname
   }
 
-  filters.prisonerName = function(person) {
+  filters.personName = function(person) {
     return person.surname + ', ' + person.first_name
   }
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -85,6 +85,7 @@ router.get('/prototype2/allocatepom', function (req, res) {
 
 function allocatePom(req, prisonerIndex, pomIndex) {
   req.session.data.prisoners[prisonerIndex].allocated = true
+  req.session.data.prisoners[prisonerIndex].allocation_date = (new Date()).toLocaleDateString('en-GB')
   req.session.data.prisoners[prisonerIndex].pomIndex = parseInt(pomIndex)
 }
 

--- a/app/views/includes/prisoner_details.html
+++ b/app/views/includes/prisoner_details.html
@@ -7,7 +7,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
         <span class="govuk-caption-m">Prisoner name</span>
-        <h3 class="govuk-heading-m">{{prisoner | prisonerName}}</h3>
+        <h3 class="govuk-heading-m">{{prisoner | personName}}</h3>
       </div>
       <div class="govuk-grid-column-one-third">
         <span class="govuk-caption-m">Prisoner number</span>

--- a/app/views/prototype1/allocation.html
+++ b/app/views/prototype1/allocation.html
@@ -33,7 +33,7 @@
   <tbody class="govuk-table__body">
     {% for prisoner in prisoners %}
     <tr class="govuk-table__row">
-      <td aria-label="Prisoner" class="govuk-table__cell" scope="row"><a href="/prototype1/prisoner/{{prisoner.id}}">{{prisoner | prisonerName}}</a></td>
+      <td aria-label="Prisoner" class="govuk-table__cell" scope="row"><a href="/prototype1/prisoner/{{prisoner.id}}">{{prisoner | personName}}</a></td>
       <td aria-label="Prisoner number" class="govuk-table__cell" scope="row">{{prisoner.number}}</td>
       <td aria-label="Sentence calc" class="govuk-table__cell" scope="row">{{prisoner.sentence_calc}}</td>
       <td aria-label="Arrival date" class="govuk-table__cell" scope="row">{{prisoner.arrival_date}}</td>

--- a/app/views/prototype1/prisoners.html
+++ b/app/views/prototype1/prisoners.html
@@ -30,7 +30,7 @@
   <tbody class="govuk-table__body">
     {% for prisoner in data['prisoners'] %}
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell" scope="row"><a href="/prototype1/prisoner/{{prisoner.id}}">{{prisoner | prisonerName}}</a></td>
+      <td class="govuk-table__cell" scope="row"><a href="/prototype1/prisoner/{{prisoner.id}}">{{prisoner | personName}}</a></td>
       <td class="govuk-table__cell" scope="row">{{prisoner.number}}</td>
       <td class="govuk-table__cell" scope="row">{{prisoner.sentence_calc}}</td>
       <td class="govuk-table__cell" scope="row">{{prisoner.arrival_date}}</td>

--- a/app/views/prototype2/allocations.html
+++ b/app/views/prototype2/allocations.html
@@ -60,13 +60,13 @@
         <tbody class="govuk-table__body">
           {% for prisoner in allocatedPrisoners %}
           <tr class="govuk-table__row">
-            <td aria-label="Prisoner name" class="govuk-table__cell">{{prisoner | prisonerName}}</td>
+            <td aria-label="Prisoner name" class="govuk-table__cell">{{prisoner | personName}}</td>
             <td aria-label="Prisoner number" class="govuk-table__cell ">{{prisoner.number}}</td>
             <td aria-label="Arrival date" class="govuk-table__cell ">{{prisoner.arrival_date}}</td>
             <td aria-label="Release date" class="govuk-table__cell ">{{prisoner.release_date}}</td>
             <td aria-label="Tier" class="govuk-table__cell ">{{prisoner.tier}}</td>
             <td aria-label="Tier" class="govuk-table__cell">{{prisoner.allocation_date}}</td>
-            <td aria-label="POM" class="govuk-table__cell">{{data.poms[prisoner.pomIndex] | prisonerName}}</td>
+            <td aria-label="POM" class="govuk-table__cell">{{data.poms[prisoner.pomIndex] | personName}}</td>
             <td aria-label="Action" class="govuk-table__cell "><a href="/prototype2/prisoner/{{prisoner.id}}">Reallocate</a></td>
           </tr>
           {% endfor %}

--- a/app/views/prototype2/allocations.html
+++ b/app/views/prototype2/allocations.html
@@ -52,7 +52,8 @@
             <th class="govuk-table__header" scope="col">Arrival date</th>
             <th class="govuk-table__header" scope="col">Release date</th>
             <th class="govuk-table__header" scope="col">Tier</th>
-            <th class="govuk-table__header" scope="col">Status change</th>
+            <th class="govuk-table__header" scope="col">Allocation Date</th>
+            <th class="govuk-table__header" scope="col">POM</th>
             <th class="govuk-table__header" scope="col">Action</th>
           </tr>
         </thead>
@@ -64,8 +65,9 @@
             <td aria-label="Arrival date" class="govuk-table__cell ">{{prisoner.arrival_date}}</td>
             <td aria-label="Release date" class="govuk-table__cell ">{{prisoner.release_date}}</td>
             <td aria-label="Tier" class="govuk-table__cell ">{{prisoner.tier}}</td>
-            <td aria-label="Status change" class="govuk-table__cell ">{{prisoner.status_change}}</td>
-            <td aria-label="Action" class="govuk-table__cell "><a href="/prototype2/prisoner/{{prisoner.id}}">Details</a></td>
+            <td aria-label="Tier" class="govuk-table__cell">{{prisoner.allocation_date}}</td>
+            <td aria-label="POM" class="govuk-table__cell">{{data.poms[prisoner.pomIndex] | prisonerName}}</td>
+            <td aria-label="Action" class="govuk-table__cell "><a href="/prototype2/prisoner/{{prisoner.id}}">Reallocate</a></td>
           </tr>
           {% endfor %}
         </tbody>

--- a/app/views/prototype2/tiering-result.html
+++ b/app/views/prototype2/tiering-result.html
@@ -13,7 +13,7 @@
     href: "javascript:window.history.back();"
   }) }}
 
-  <h1 class="govuk-heading-l">Tiering calculation for {{prisoner | prisonerName}} ({{prisoner.number}})</h1>
+  <h1 class="govuk-heading-l">Tiering calculation for {{prisoner | personName}} ({{prisoner.number}})</h1>
 
   <div class="govuk-panel govuk-panel--confirmation">
     <h1 class="govuk-panel__title">

--- a/app/views/prototype2/tiering.html
+++ b/app/views/prototype2/tiering.html
@@ -13,7 +13,7 @@
     href: "javascript:window.history.back();"
   }) }}
 
-  <h1 class="govuk-heading-l">Tiering for {{prisoner | prisonerName}} ({{prisoner.number}})</h1>
+  <h1 class="govuk-heading-l">Tiering for {{prisoner | personName}} ({{prisoner.number}})</h1>
 
   {{ govukRadios({
     classes: "govuk-radios",


### PR DESCRIPTION
Adds the extra information on the allocated tab as per the prototype and
updates allocation to remember the allocation date.

It also tweaks the seed data for allocated prisoners to have a pom.