### PR TITLE
Re-introduce icon for sortable columns (default state)

### DIFF
--- a/app/assets/sass/_tablesort.scss
+++ b/app/assets/sass/_tablesort.scss
@@ -14,6 +14,10 @@ table.tablesorter {
     cursor: auto;
     background: none !important;
   }
+  th.tablesorter-header-none .tablesorter-header-inner {
+    background: url('../images/black-unsorted.gif') no-repeat right center;
+  }
+
   .tablesorter-header-inner a:visited {
     color: $govuk-blue;
   }


### PR DESCRIPTION
<img width="1680" alt="screen shot 2018-09-28 at 14 04 03" src="https://user-images.githubusercontent.com/5256922/46210057-8fe39e00-c327-11e8-966f-e0b9dee3765a.png">
